### PR TITLE
feat!: SharedFiles now returns PublicFileMetadata

### DIFF
--- a/backend/did/src/orchestrator.rs
+++ b/backend/did/src/orchestrator.rs
@@ -1,4 +1,5 @@
 mod pagination;
+mod public_file_metadata;
 mod shared_files;
 mod user;
 mod user_canister;
@@ -8,8 +9,9 @@ use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
 
 pub use self::pagination::Pagination;
+pub use self::public_file_metadata::PublicFileMetadata;
 pub use self::shared_files::{
-    FileId, RevokeShareFileResponse, ShareFileResponse, SharedFilesResponse,
+    FileId, RevokeShareFileResponse, ShareFileMetadata, ShareFileResponse, SharedFilesResponse,
 };
 pub use self::user::{
     GetUsersResponse, GetUsersResponseUsers, MAX_USERNAME_SIZE, PUBKEY_SIZE, PublicKey, PublicUser,

--- a/backend/did/src/orchestrator/public_file_metadata.rs
+++ b/backend/did/src/orchestrator/public_file_metadata.rs
@@ -1,0 +1,11 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+use super::FileId;
+
+/// Public file metadata which is stored for the shared files info
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PublicFileMetadata {
+    pub file_id: FileId,
+    pub file_name: String,
+}

--- a/backend/did/src/orchestrator/shared_files.rs
+++ b/backend/did/src/orchestrator/shared_files.rs
@@ -1,7 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use candid::{CandidType, Principal};
+use ic_stable_structures::Storable;
+use ic_stable_structures::storable::Bound;
 use serde::{Deserialize, Serialize};
+
+use super::public_file_metadata::PublicFileMetadata;
 
 /// File ID type
 pub type FileId = u64;
@@ -32,9 +36,52 @@ pub enum RevokeShareFileResponse {
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum SharedFilesResponse {
     /// List of shared files
-    SharedFiles(HashMap<Principal, HashSet<FileId>>),
+    SharedFiles(HashMap<Principal, Vec<PublicFileMetadata>>),
     /// No such user
     NoSuchUser,
     /// Anonymous user
     AnonymousUser,
+}
+
+/// File metadata of a shared file
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize, Serialize)]
+pub struct ShareFileMetadata {
+    pub file_name: String,
+}
+
+impl Storable for ShareFileMetadata {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        let len: u64 = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        let file_name = String::from_utf8(bytes[8..(8 + len as usize)].to_vec()).unwrap();
+
+        ShareFileMetadata { file_name }
+    }
+
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        let file_name_bytes = self.file_name.as_bytes();
+        let len = file_name_bytes.len() as u64;
+        let mut bytes = Vec::with_capacity(8 + len as usize);
+        bytes.extend_from_slice(&len.to_le_bytes());
+        bytes.extend_from_slice(file_name_bytes);
+        bytes.into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_shared_files_roundtrip() {
+        let file_name = "test_file.txt".to_string();
+        let metadata = ShareFileMetadata { file_name };
+
+        let bytes = metadata.to_bytes();
+        let deserialized_metadata = ShareFileMetadata::from_bytes(bytes);
+
+        assert_eq!(metadata, deserialized_metadata);
+    }
 }

--- a/backend/orchestrator/src/canister.rs
+++ b/backend/orchestrator/src/canister.rs
@@ -4,9 +4,9 @@ use candid::Principal;
 use create_user::CreateUserStateMachine;
 use did::orchestrator::{
     FileId, GetUsersResponse, GetUsersResponseUsers, MAX_USERNAME_SIZE, OrchestratorInstallArgs,
-    Pagination, PublicKey, PublicUser, RetryUserCanisterCreationResponse, RevokeShareFileResponse,
-    SetUserResponse, ShareFileResponse, SharedFilesResponse, User, UserCanisterResponse,
-    WhoamiResponse,
+    Pagination, PublicFileMetadata, PublicKey, PublicUser, RetryUserCanisterCreationResponse,
+    RevokeShareFileResponse, SetUserResponse, ShareFileMetadata, ShareFileResponse,
+    SharedFilesResponse, User, UserCanisterResponse, WhoamiResponse,
 };
 
 use crate::storage::config::Config;
@@ -206,8 +206,12 @@ impl Canister {
     /// - [`ShareFileResponse::Ok`] if the file was shared successfully.
     /// - [`ShareFileResponse::NoSuchUser`] if the user doesn't exist.
     /// - [`ShareFileResponse::Unauthorized`] if the caller is not a user canister.
-    pub fn share_file(user: Principal, file_id: FileId) -> ShareFileResponse {
-        Self::share_file_with_users(vec![user], file_id)
+    pub fn share_file(
+        user: Principal,
+        file_id: FileId,
+        metadata: ShareFileMetadata,
+    ) -> ShareFileResponse {
+        Self::share_file_with_users(vec![user], file_id, metadata)
     }
 
     /// Share a file with many users.
@@ -217,7 +221,11 @@ impl Canister {
     /// - [`ShareFileResponse::Ok`] if the file was shared successfully.
     /// - [`ShareFileResponse::NoSuchUser`] if the user doesn't exist.
     /// - [`ShareFileResponse::Unauthorized`] if the caller is not a user canister.
-    pub fn share_file_with_users(users: Vec<Principal>, file_id: FileId) -> ShareFileResponse {
+    pub fn share_file_with_users(
+        users: Vec<Principal>,
+        file_id: FileId,
+        metadata: ShareFileMetadata,
+    ) -> ShareFileResponse {
         let user_canister = msg_caller();
         // check if the caller is a user canister
         if !UserCanisterStorage::is_user_canister(user_canister) {
@@ -234,7 +242,7 @@ impl Canister {
 
         // share the file with all the users
         for user in users {
-            SharedFilesStorage::share_file(user, user_canister, file_id);
+            SharedFilesStorage::share_file(user, user_canister, file_id, metadata.clone());
         }
 
         ShareFileResponse::Ok
@@ -258,7 +266,27 @@ impl Canister {
             return SharedFilesResponse::NoSuchUser;
         }
 
-        SharedFilesResponse::SharedFiles(SharedFilesStorage::get_shared_files(caller))
+        SharedFilesResponse::SharedFiles(
+            SharedFilesStorage::get_shared_files(caller)
+                .into_iter()
+                .map(|(user_canister, files)| {
+                    (
+                        user_canister,
+                        files
+                            .into_iter()
+                            .filter_map(|file_id| {
+                                SharedFilesStorage::get_file_metadata(user_canister, file_id).map(
+                                    |file_metadata| PublicFileMetadata {
+                                        file_id,
+                                        file_name: file_metadata.file_name,
+                                    },
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        )
     }
 
     /// Checks whether a given username exists in the storage.
@@ -651,10 +679,25 @@ mod test {
         let file_id = 1;
         let user_canister = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
 
-        SharedFilesStorage::share_file(principal, user_canister, file_id);
+        SharedFilesStorage::share_file(
+            principal,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
 
         let mut expected = HashMap::new();
-        expected.insert(user_canister, vec![file_id].into_iter().collect());
+        expected.insert(
+            user_canister,
+            vec![PublicFileMetadata {
+                file_id,
+                file_name: "foo.txt".to_string(),
+            }]
+            .into_iter()
+            .collect(),
+        );
 
         // get shared files
         let shared_files = Canister::shared_files();
@@ -681,7 +724,14 @@ mod test {
 
         // revoke share
         let file_id = 1;
-        SharedFilesStorage::share_file(user, user_canister, file_id);
+        SharedFilesStorage::share_file(
+            user,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         let response = Canister::revoke_share_file(user, file_id);
         assert_eq!(response, RevokeShareFileResponse::Ok);
 
@@ -700,7 +750,14 @@ mod test {
 
         // revoke share
         let file_id = 1;
-        SharedFilesStorage::share_file(user, user_canister, file_id);
+        SharedFilesStorage::share_file(
+            user,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         let response = Canister::revoke_share_file(user, file_id);
         assert_eq!(response, RevokeShareFileResponse::Unauthorized);
 
@@ -724,9 +781,30 @@ mod test {
 
         // revoke share
         let file_id = 1;
-        SharedFilesStorage::share_file(user, user_canister, file_id);
-        SharedFilesStorage::share_file(user_2, user_canister, file_id);
-        SharedFilesStorage::share_file(user_3, user_canister, file_id);
+        SharedFilesStorage::share_file(
+            user,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
+        SharedFilesStorage::share_file(
+            user_2,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
+        SharedFilesStorage::share_file(
+            user_3,
+            user_canister,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         let response = Canister::revoke_share_file_for_users(vec![user, user_2], file_id);
         assert_eq!(response, RevokeShareFileResponse::Ok);
 
@@ -762,7 +840,13 @@ mod test {
 
         // share file
         let file_id = 1;
-        let response = Canister::share_file(alice, file_id);
+        let response = Canister::share_file(
+            alice,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         assert_eq!(response, ShareFileResponse::Ok);
 
         // check if the file is shared
@@ -778,7 +862,13 @@ mod test {
 
         // share file
         let file_id = 1;
-        let response = Canister::share_file(user, file_id);
+        let response = Canister::share_file(
+            user,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         assert_eq!(response, ShareFileResponse::Unauthorized);
 
         // check if the file is NOT shared
@@ -801,7 +891,13 @@ mod test {
 
         // share file
         let file_id = 1;
-        let response = Canister::share_file(alice, file_id);
+        let response = Canister::share_file(
+            alice,
+            file_id,
+            ShareFileMetadata {
+                file_name: "foo.txt".to_string(),
+            },
+        );
         assert_eq!(response, ShareFileResponse::NoSuchUser(alice));
 
         // check if the file is NOT shared

--- a/backend/orchestrator/src/lib.rs
+++ b/backend/orchestrator/src/lib.rs
@@ -6,8 +6,8 @@ mod utils;
 use candid::Principal;
 use did::orchestrator::{
     FileId, GetUsersResponse, OrchestratorInstallArgs, Pagination, PublicKey,
-    RetryUserCanisterCreationResponse, RevokeShareFileResponse, SetUserResponse, ShareFileResponse,
-    SharedFilesResponse, UserCanisterResponse, WhoamiResponse,
+    RetryUserCanisterCreationResponse, RevokeShareFileResponse, SetUserResponse, ShareFileMetadata,
+    ShareFileResponse, SharedFilesResponse, UserCanisterResponse, WhoamiResponse,
 };
 use ic_cdk_macros::{init, query, update};
 
@@ -53,13 +53,21 @@ pub fn set_user(username: String, public_key: PublicKey) -> SetUserResponse {
 }
 
 #[update]
-pub fn share_file(user: Principal, file_id: FileId) -> ShareFileResponse {
-    Canister::share_file(user, file_id)
+pub fn share_file(
+    user: Principal,
+    file_id: FileId,
+    metadata: ShareFileMetadata,
+) -> ShareFileResponse {
+    Canister::share_file(user, file_id, metadata)
 }
 
 #[update]
-pub fn share_file_with_users(users: Vec<Principal>, file_id: FileId) -> ShareFileResponse {
-    Canister::share_file_with_users(users, file_id)
+pub fn share_file_with_users(
+    users: Vec<Principal>,
+    file_id: FileId,
+    metadata: ShareFileMetadata,
+) -> ShareFileResponse {
+    Canister::share_file_with_users(users, file_id, metadata)
 }
 
 #[query]

--- a/backend/orchestrator/src/storage/memory.rs
+++ b/backend/orchestrator/src/storage/memory.rs
@@ -12,6 +12,8 @@ pub const USER_CANISTERS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(21);
 pub const USER_CANISTER_CREATE_STATES_MEMORY_ID: MemoryId = MemoryId::new(22);
 
 pub const SHARED_FILES_MEMORY_ID: MemoryId = MemoryId::new(30);
+pub const SHARED_FILES_METADATA_MEMORY_ID: MemoryId = MemoryId::new(31);
+pub const SHARED_FILES_METADATA_RC_MEMORY_ID: MemoryId = MemoryId::new(32);
 
 thread_local! {
     /// Memory manager

--- a/backend/orchestrator/src/storage/shared_files.rs
+++ b/backend/orchestrator/src/storage/shared_files.rs
@@ -5,17 +5,32 @@ use std::collections::{HashMap, HashSet};
 
 use candid::Principal;
 use did::StorablePrincipal;
-use did::orchestrator::FileId;
+use did::orchestrator::{FileId, ShareFileMetadata};
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
 
 use self::user_shared_files::UserSharedFiles;
-use crate::storage::memory::{MEMORY_MANAGER, SHARED_FILES_MEMORY_ID};
+use crate::storage::memory::{
+    MEMORY_MANAGER, SHARED_FILES_MEMORY_ID, SHARED_FILES_METADATA_MEMORY_ID,
+    SHARED_FILES_METADATA_RC_MEMORY_ID,
+};
 
 thread_local! {
     /// Shared files. Maps users to their shared files, grouped by the user canister.
     static SHARED_FILES: RefCell<StableBTreeMap<StorablePrincipal, UserSharedFiles, VirtualMemory<DefaultMemoryImpl>>> =
         RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(SHARED_FILES_MEMORY_ID)))
+    );
+
+    /// Metadata for shared files. Maps userCanister AND file IDs to their metadata.
+    static SHARED_FILES_METADATA: RefCell<StableBTreeMap<(StorablePrincipal, FileId), ShareFileMetadata, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(SHARED_FILES_METADATA_MEMORY_ID)))
+    );
+
+    /// Tracks the number of references to shared files metadata.
+    ///
+    /// This is used to determine if the metadata can be removed from the stable memory.
+    static SHARED_FILES_METADATA_RC: RefCell<StableBTreeMap<(StorablePrincipal, FileId), u64, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(SHARED_FILES_METADATA_RC_MEMORY_ID)))
     );
 }
 
@@ -28,7 +43,12 @@ impl SharedFilesStorage {
     /// Share a file with a user for the provided user canister.
     ///
     /// Marks the file as shared for the user canister
-    pub fn share_file(user: Principal, user_canister: Principal, file_id: FileId) {
+    pub fn share_file(
+        user: Principal,
+        user_canister: Principal,
+        file_id: FileId,
+        metadata: ShareFileMetadata,
+    ) {
         SHARED_FILES.with_borrow_mut(|shared_files| {
             let storable_user = StorablePrincipal::from(user);
             if !shared_files.contains_key(&storable_user) {
@@ -42,7 +62,20 @@ impl SharedFilesStorage {
             user_shared_files.insert_file(user_canister, file_id);
 
             shared_files.insert(storable_user, user_shared_files);
-        })
+        });
+
+        // insert the file metadata
+        SHARED_FILES_METADATA.with_borrow_mut(|shared_files_metadata| {
+            shared_files_metadata.insert((user_canister.into(), file_id), metadata);
+        });
+
+        // increment the reference count
+        SHARED_FILES_METADATA_RC.with_borrow_mut(|shared_files_metadata_rc| {
+            let rc = shared_files_metadata_rc
+                .get(&(user_canister.into(), file_id))
+                .unwrap_or(0);
+            shared_files_metadata_rc.insert((user_canister.into(), file_id), rc + 1);
+        });
     }
 
     /// Revoke a file share for a user for the provided user canister.
@@ -65,7 +98,30 @@ impl SharedFilesStorage {
             } else {
                 shared_files.insert(storable_user, user_shared_files);
             }
-        })
+        });
+
+        // decrement the reference count
+        let rc = SHARED_FILES_METADATA_RC.with_borrow_mut(|shared_files_metadata_rc| {
+            let rc = shared_files_metadata_rc
+                .get(&(user_canister.into(), file_id))
+                .unwrap_or(0)
+                .checked_sub(1)
+                .unwrap_or_default();
+            if rc > 0 {
+                shared_files_metadata_rc.insert((user_canister.into(), file_id), rc);
+            } else {
+                shared_files_metadata_rc.remove(&(user_canister.into(), file_id));
+            }
+
+            rc
+        });
+
+        // remove the file metadata if the reference count is 0
+        if rc == 0 {
+            SHARED_FILES_METADATA.with_borrow_mut(|shared_files_metadata| {
+                shared_files_metadata.remove(&(user_canister.into(), file_id));
+            });
+        }
     }
 
     /// For a user, get the list of file IDs shared for each user canister.
@@ -77,6 +133,16 @@ impl SharedFilesStorage {
                 .get(&storable_user)
                 .map(|user_shared_files| user_shared_files.get_files())
                 .unwrap_or_default()
+        })
+    }
+
+    /// Get the metadata for a file shared with a user.
+    pub fn get_file_metadata(
+        user_canister: Principal,
+        file_id: FileId,
+    ) -> Option<ShareFileMetadata> {
+        SHARED_FILES_METADATA.with_borrow(|shared_files_metadata| {
+            shared_files_metadata.get(&(user_canister.into(), file_id))
         })
     }
 }
@@ -95,9 +161,30 @@ mod test {
         let user_canister_b = Principal::from_slice(&[4; 29]);
 
         // insert
-        SharedFilesStorage::share_file(alice, user_canister_a, 1);
-        SharedFilesStorage::share_file(alice, user_canister_b, 2);
-        SharedFilesStorage::share_file(bob, user_canister_a, 1);
+        SharedFilesStorage::share_file(
+            alice,
+            user_canister_a,
+            1,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
+        SharedFilesStorage::share_file(
+            alice,
+            user_canister_b,
+            2,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
+        SharedFilesStorage::share_file(
+            bob,
+            user_canister_a,
+            1,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
 
         // check
         let alice_files = SharedFilesStorage::get_shared_files(alice);
@@ -119,8 +206,22 @@ mod test {
         let user_canister_a = Principal::from_slice(&[3; 29]);
 
         // insert
-        SharedFilesStorage::share_file(alice, user_canister_a, 1);
-        SharedFilesStorage::share_file(alice, user_canister_a, 2);
+        SharedFilesStorage::share_file(
+            alice,
+            user_canister_a,
+            1,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
+        SharedFilesStorage::share_file(
+            alice,
+            user_canister_a,
+            2,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
 
         // revoke
         SharedFilesStorage::revoke_share(alice, user_canister_a, 1);
@@ -138,5 +239,78 @@ mod test {
         // check
         let alice_files = SharedFilesStorage::get_shared_files(alice);
         assert_eq!(alice_files.len(), 0);
+    }
+
+    #[test]
+    fn test_share_file_should_set_metadata_and_remove_them() {
+        let alice = Principal::from_slice(&[1; 29]);
+        let bob = Principal::from_slice(&[2; 29]);
+
+        let user_canister_a = Principal::from_slice(&[3; 29]);
+
+        SharedFilesStorage::share_file(
+            alice,
+            user_canister_a,
+            1,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
+
+        SharedFilesStorage::share_file(
+            bob,
+            user_canister_a,
+            1,
+            ShareFileMetadata {
+                file_name: "test.txt".to_string(),
+            },
+        );
+
+        // check metadata
+        let metadata = SHARED_FILES_METADATA.with_borrow(|shared_files_metadata| {
+            shared_files_metadata
+                .get(&(user_canister_a.into(), 1))
+                .unwrap()
+        });
+        assert_eq!(metadata.file_name, "test.txt".to_string());
+
+        // check reference count
+        let rc = SHARED_FILES_METADATA_RC.with_borrow(|shared_files_metadata_rc| {
+            shared_files_metadata_rc
+                .get(&(user_canister_a.into(), 1))
+                .unwrap()
+        });
+        assert_eq!(rc, 2);
+
+        // revoke for bob
+        SharedFilesStorage::revoke_share(bob, user_canister_a, 1);
+        // check reference count
+        let rc = SHARED_FILES_METADATA_RC.with_borrow(|shared_files_metadata_rc| {
+            shared_files_metadata_rc
+                .get(&(user_canister_a.into(), 1))
+                .unwrap()
+        });
+        assert_eq!(rc, 1);
+
+        // check metadata
+        let metadata = SHARED_FILES_METADATA.with_borrow(|shared_files_metadata| {
+            shared_files_metadata
+                .get(&(user_canister_a.into(), 1))
+                .unwrap()
+        });
+        assert_eq!(metadata.file_name, "test.txt".to_string());
+
+        // revoke for alice
+        SharedFilesStorage::revoke_share(alice, user_canister_a, 1);
+        // check reference count
+        let rc = SHARED_FILES_METADATA_RC.with_borrow(|shared_files_metadata_rc| {
+            shared_files_metadata_rc.get(&(user_canister_a.into(), 1))
+        });
+        assert!(rc.is_none());
+        // check metadata
+        let metadata = SHARED_FILES_METADATA.with_borrow(|shared_files_metadata| {
+            shared_files_metadata.get(&(user_canister_a.into(), 1))
+        });
+        assert!(metadata.is_none());
     }
 }

--- a/backend/user_canister/src/client/orchestrator.rs
+++ b/backend/user_canister/src/client/orchestrator.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use did::orchestrator::{FileId, RevokeShareFileResponse, ShareFileResponse};
+use did::orchestrator::{FileId, RevokeShareFileResponse, ShareFileMetadata, ShareFileResponse};
 use ic_cdk::call::{Call, CallResult, Error as CallError};
 
 /// Orchestrator canister client.
@@ -57,9 +57,10 @@ impl OrchestratorClient {
         &self,
         user: Principal,
         file_id: FileId,
+        metadata: ShareFileMetadata,
     ) -> CallResult<ShareFileResponse> {
         Call::unbounded_wait(self.principal, "share_file")
-            .with_args(&(user, file_id))
+            .with_args(&(user, file_id, metadata))
             .await
             .map_err(CallError::from)?
             .candid::<ShareFileResponse>()
@@ -71,9 +72,10 @@ impl OrchestratorClient {
         &self,
         users: &[Principal],
         file_id: FileId,
+        metadata: ShareFileMetadata,
     ) -> CallResult<ShareFileResponse> {
         Call::unbounded_wait(self.principal, "share_file_with_users")
-            .with_args(&(users, file_id))
+            .with_args(&(users, file_id, metadata))
             .await
             .map_err(CallError::from)?
             .candid::<ShareFileResponse>()

--- a/integration-tests/tests/pocket_ic/orchestrator.rs
+++ b/integration-tests/tests/pocket_ic/orchestrator.rs
@@ -163,7 +163,11 @@ async fn test_should_return_shared_files() {
         .get(&env.user_canister())
         .expect("Expected file on owner canister");
     assert_eq!(shared_file_on_owner_canister.len(), 1);
-    assert!(shared_file_on_owner_canister.contains(&file_id));
+    assert!(
+        shared_file_on_owner_canister
+            .iter()
+            .any(|it| it.file_id == file_id)
+    );
 
     env.stop().await;
 }


### PR DESCRIPTION
Added ShareMetadata argument to orchestrator endpoints. Added two maps to store those metadata. One is indexed by (UserCanister, FileId) -> FileMetadata, and the other is a reference counter to know how many users are sharing that file. Actually we can USE this map to also know how many users have access to that file. When the map is empty, we can finally remove the metadata to preserve storage

BREAKING CHANGE: Changed the api

Actually we'll REMOVE the RC map once we have the shared_with field, because with that map we'll be able to know exactly how many users have that shared file with.