### PR TITLE
feat(user-canister)!: Files are now indexed ALSO with their Path

### DIFF
--- a/backend/did/src/user_canister.rs
+++ b/backend/did/src/user_canister.rs
@@ -1,6 +1,9 @@
 mod delete_file;
 mod file;
 mod owner_key;
+mod path;
+mod request_file;
+mod upload_file_atomic;
 
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
@@ -12,6 +15,9 @@ pub use self::file::{
     UploadFileContinueResponse, UploadFileError, UploadFileRequest,
 };
 pub use self::owner_key::OwnerKey;
+pub use self::path::Path;
+pub use self::request_file::RequestFileResponse;
+pub use self::upload_file_atomic::UploadFileAtomicResponse;
 pub use crate::public_key::PublicKey;
 
 /// User Canister canister install arguments.

--- a/backend/did/src/user_canister/file.rs
+++ b/backend/did/src/user_canister/file.rs
@@ -1,13 +1,14 @@
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
 
-use super::{OwnerKey, PublicKey};
+use super::{OwnerKey, Path, PublicKey};
 
 /// Public file metadata
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct PublicFileMetadata {
     pub file_id: u64,
     pub file_name: String,
+    pub file_path: Path,
     pub file_status: FileStatus,
     pub shared_with: Vec<Principal>,
 }
@@ -43,6 +44,7 @@ pub enum GetAliasInfoError {
 pub struct AliasInfo {
     pub file_id: u64,
     pub file_name: String,
+    pub file_path: Path,
     pub public_key: PublicKey,
 }
 
@@ -110,7 +112,7 @@ pub struct UploadFileRequest {
 /// File upload atomic request
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct UploadFileAtomicRequest {
-    pub name: String,
+    pub path: Path,
     pub content: Vec<u8>,
     pub owner_key: OwnerKey,
     pub file_type: String,

--- a/backend/did/src/user_canister/path.rs
+++ b/backend/did/src/user_canister/path.rs
@@ -1,0 +1,290 @@
+use std::rc::Rc;
+use std::str::FromStr;
+
+use candid::CandidType;
+use candid::types::{Type, TypeInner};
+use ic_stable_structures::Storable;
+use ic_stable_structures::storable::Bound;
+use serde::{Deserialize, Serialize};
+
+/// Maximum size of a file path.
+const MAX_PATH_SIZE: usize = 4096;
+
+/// File Path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Path(String);
+
+impl CandidType for Path {
+    fn _ty() -> candid::types::Type {
+        Type(Rc::new(TypeInner::Text))
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: candid::types::Serializer,
+    {
+        serializer.serialize_text(&self.0)
+    }
+}
+
+impl Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Path {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        let p = Path(s);
+        p.validate()
+            .map_err(|e| serde::de::Error::custom(format!("Invalid path: {}", e)))?;
+        Ok(p)
+    }
+}
+
+impl Storable for Path {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: MAX_PATH_SIZE as u32 + 2,
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        // write len of path
+        let path_len: u16 = self.0.len() as u16;
+        let mut bytes = Vec::with_capacity(self.0.len() + 2);
+        bytes.extend_from_slice(&path_len.to_le_bytes());
+        // write path
+        bytes.extend_from_slice(self.0.as_bytes());
+
+        bytes.into()
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        // read len of path
+        let path_len = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
+        // read path
+        let path = String::from_utf8(bytes[2..2 + path_len].to_vec())
+            .expect("Invalid UTF-8 sequence in path");
+
+        let p = Self(path);
+        p.validate_dangerous(); // Validate the path
+        p
+    }
+}
+
+impl FromStr for Path {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let p = Path(s.to_string());
+        p.validate()?;
+        Ok(p)
+    }
+}
+
+impl TryFrom<String> for Path {
+    type Error = &'static str;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}
+
+impl Path {
+    /// Creates a new [`Path`] from a string.
+    ///
+    /// It is equivalent to `Path::try_from(path)`.
+    pub fn new(path: impl ToString) -> Result<Self, &'static str> {
+        Self::try_from(path.to_string())
+    }
+
+    /// Returns components of the path as an iterator.
+    pub fn components(&self) -> impl Iterator<Item = &str> {
+        // Skip the leading empty component
+        self.0.split('/').filter(|s| !s.is_empty())
+    }
+
+    /// Get the parent [`Path`] of this path.
+    pub fn parent(&self) -> Option<Path> {
+        let components: Vec<&str> = self.components().collect();
+        if components.is_empty() {
+            None // No parent for root or empty path
+        } else {
+            let mut p = String::from("/");
+            p.push_str(&components[..components.len() - 1].join("/"));
+            Some(Self(p))
+        }
+    }
+
+    /// Get the file name from the path.
+    pub fn file_name(&self) -> Option<&str> {
+        self.components().last()
+    }
+
+    /// Returns `true` if the path is a directory.
+    pub fn is_dir(&self) -> bool {
+        // A path is considered a directory if it ends with a '/'
+        self.0.ends_with('/')
+    }
+
+    /// Returns `true` if the path is a file.
+    pub fn is_file(&self) -> bool {
+        // A path is considered a file if it does not end with a '/'
+        !self.is_dir()
+    }
+
+    /// Validates the path.
+    ///
+    /// A [`Path`] is valid if it:
+    ///
+    /// - Is not empty.
+    /// - Starts with `/`
+    /// - Does not contain `..` or `.` segments.
+    ///
+    /// # Panics
+    ///
+    /// If the path is invalid, this method will panic.
+    fn validate_dangerous(&self) {
+        self.validate().expect("Path validation failed");
+    }
+
+    /// Validates the path and returns a [`Result`].
+    /// A [`Path`] is valid if it:
+    ///
+    /// - Is not empty.
+    /// - Starts with `/`
+    /// - Does not contain `..` or `.` segments.
+    fn validate(&self) -> Result<(), &'static str> {
+        let p = self.0.as_str();
+        if p.is_empty() {
+            return Err("Path cannot be empty");
+        }
+        if !p.starts_with('/') {
+            return Err("Path must start with '/'");
+        }
+        if self.components().any(|c| c == ".." || c == ".") {
+            return Err("Path cannot contain '..' or '.' segments");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use candid::{Decode, Encode};
+
+    use super::*;
+
+    #[test]
+    fn test_should_create_valid_path() {
+        let path = Path::new("/valid/path".to_string());
+        assert!(path.is_ok());
+    }
+
+    #[test]
+    fn test_should_fail_on_empty_path() {
+        let path = Path::new("".to_string());
+        assert!(path.is_err());
+        assert_eq!(path.err(), Some("Path cannot be empty"));
+    }
+
+    #[test]
+    fn test_should_fail_on_invalid_start() {
+        let path = Path::new("invalid/path".to_string());
+        assert!(path.is_err());
+        assert_eq!(path.err(), Some("Path must start with '/'"));
+    }
+
+    #[test]
+    fn test_should_fail_on_invalid_segments() {
+        let path = Path::new("/invalid/../path".to_string());
+        assert!(path.is_err());
+        assert_eq!(path.err(), Some("Path cannot contain '..' or '.' segments"));
+
+        let path = Path::new("/invalid/./path".to_string());
+        assert!(path.is_err());
+        assert_eq!(path.err(), Some("Path cannot contain '..' or '.' segments"));
+    }
+
+    #[test]
+    fn test_should_get_parent_path() {
+        let path = Path::new("/valid/path".to_string()).unwrap();
+        assert_eq!(path.parent(), Some(Path("/valid".to_string())));
+
+        let root_path = Path::new("/".to_string()).unwrap();
+        assert_eq!(root_path.parent(), None);
+
+        let single_component_path = Path::new("/single".to_string()).unwrap();
+        assert_eq!(single_component_path.parent(), Some(Path("/".to_string())));
+    }
+
+    #[test]
+    fn test_should_split_path_into_components() {
+        let path = Path::new("/valid/path/with/components".to_string()).unwrap();
+        let components: Vec<&str> = path.components().collect();
+        assert_eq!(components, vec!["valid", "path", "with", "components"]);
+    }
+
+    #[test]
+    fn test_should_serialize_and_deserialize_path() {
+        let path = Path::new("/valid/path".to_string()).unwrap();
+        let serialized = Encode!(&path).unwrap();
+        let deserialized = Decode!(&serialized, Path).unwrap();
+        assert_eq!(path, deserialized);
+    }
+
+    #[test]
+    fn test_path_storable_roundtrip() {
+        let path = Path::new("/valid/path".to_string()).unwrap();
+        let bytes = path.to_bytes();
+        let deserialized_path = Path::from_bytes(bytes);
+        assert_eq!(path, deserialized_path);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_should_panic_when_deserializing_invalid_path() {
+        let invalid_path = Path("invalid/path".to_string());
+        let serialized = Encode!(&invalid_path).unwrap();
+        let _deserialized = Decode!(&serialized, Path).unwrap();
+    }
+
+    #[test]
+    fn test_should_get_file_name() {
+        let path = Path::new("/valid/path/file.txt".to_string()).unwrap();
+        assert_eq!(path.file_name(), Some("file.txt"));
+
+        let root_path = Path::new("/file.txt".to_string()).unwrap();
+        assert_eq!(root_path.file_name(), Some("file.txt"));
+
+        let single_component_path = Path::new("/single".to_string()).unwrap();
+        assert_eq!(single_component_path.file_name(), Some("single"));
+
+        let empty_path = Path::new("/".to_string()).unwrap();
+        assert_eq!(empty_path.file_name(), None);
+    }
+
+    #[test]
+    fn test_should_identify_directory_and_file_paths() {
+        let dir_path = Path::new("/valid/path/".to_string()).unwrap();
+        assert!(dir_path.is_dir());
+        assert!(!dir_path.is_file());
+
+        let file_path = Path::new("/valid/path/file.txt".to_string()).unwrap();
+        assert!(!file_path.is_dir());
+        assert!(file_path.is_file());
+
+        let root_dir = Path::new("/".to_string()).unwrap();
+        assert!(root_dir.is_dir());
+        assert!(!root_dir.is_file());
+    }
+}

--- a/backend/did/src/user_canister/request_file.rs
+++ b/backend/did/src/user_canister/request_file.rs
@@ -1,0 +1,23 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+/// Request file result enum.
+///
+/// In case of success returns [`RequestFileResponse::Ok`] with the alias name.
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq)]
+pub enum RequestFileResponse {
+    /// Return the alias name
+    Ok(String),
+    FileAlreadyExists,
+}
+
+impl RequestFileResponse {
+    pub fn unwrap(self) -> String {
+        match self {
+            RequestFileResponse::Ok(file_id) => file_id,
+            e => {
+                panic!("Tried to unwrap a {e:?} response")
+            }
+        }
+    }
+}

--- a/backend/did/src/user_canister/upload_file_atomic.rs
+++ b/backend/did/src/user_canister/upload_file_atomic.rs
@@ -1,0 +1,24 @@
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+use crate::FileId;
+
+/// Response for the `upload_file_atomic` method.
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq)]
+pub enum UploadFileAtomicResponse {
+    /// The file was uploaded successfully.
+    Ok(FileId),
+    /// File already exists.
+    FileAlreadyExists,
+}
+
+impl UploadFileAtomicResponse {
+    pub fn unwrap(self) -> FileId {
+        match self {
+            UploadFileAtomicResponse::Ok(file_id) => file_id,
+            e => {
+                panic!("Tried to unwrap a {e:?} response")
+            }
+        }
+    }
+}

--- a/backend/user_canister/src/lib.rs
+++ b/backend/user_canister/src/lib.rs
@@ -10,8 +10,9 @@ use did::FileId;
 use did::orchestrator::PublicKey;
 use did::user_canister::{
     AliasInfo, DeleteFileResponse, FileDownloadResponse, FileSharingResponse, GetAliasInfoError,
-    OwnerKey, PublicFileMetadata, UploadFileAtomicRequest, UploadFileContinueRequest,
-    UploadFileContinueResponse, UploadFileError, UploadFileRequest, UserCanisterInstallArgs,
+    OwnerKey, Path, PublicFileMetadata, RequestFileResponse, UploadFileAtomicRequest,
+    UploadFileAtomicResponse, UploadFileContinueRequest, UploadFileContinueResponse,
+    UploadFileError, UploadFileRequest, UserCanisterInstallArgs,
 };
 use ic_cdk_macros::{init, query, update};
 use storage::config::Config;
@@ -66,7 +67,7 @@ fn upload_file(request: UploadFileRequest) -> Result<(), UploadFileError> {
 }
 
 #[update]
-fn upload_file_atomic(request: UploadFileAtomicRequest) -> u64 {
+fn upload_file_atomic(request: UploadFileAtomicRequest) -> UploadFileAtomicResponse {
     Canister::upload_file_atomic(msg_caller(), request)
 }
 
@@ -76,8 +77,8 @@ fn upload_file_continue(request: UploadFileContinueRequest) -> UploadFileContinu
 }
 
 #[update]
-async fn request_file(request_name: String) -> String {
-    Canister::request_file(msg_caller(), request_name).await
+async fn request_file(path: Path) -> RequestFileResponse {
+    Canister::request_file(msg_caller(), path).await
 }
 
 #[query]

--- a/backend/user_canister/src/storage/files/data_storage.rs
+++ b/backend/user_canister/src/storage/files/data_storage.rs
@@ -37,7 +37,6 @@ mod test {
         let file_id = 1;
         let file = File {
             metadata: FileMetadata {
-                file_name: "test_file".to_string(),
                 user_public_key: vec![0; 32].try_into().unwrap(),
                 requester_principal: Principal::from_slice(&[1; 29]),
                 requested_at: 0,
@@ -58,7 +57,6 @@ mod test {
         let file_id = 1;
         let file = File {
             metadata: FileMetadata {
-                file_name: "test_file".to_string(),
                 user_public_key: vec![1; 32].try_into().unwrap(),
                 requester_principal: Principal::from_slice(&[1; 29]),
                 requested_at: 0,

--- a/backend/user_canister/src/storage/files/path_storage.rs
+++ b/backend/user_canister/src/storage/files/path_storage.rs
@@ -1,0 +1,95 @@
+use did::user_canister::Path;
+
+use super::{FILE_ID_TO_PATH, FILE_PATH_TO_ID, FileId};
+
+/// Storage for file paths in the user canister.
+pub struct PathStorage;
+
+impl PathStorage {
+    /// Create a new file path storage entry.
+    pub fn create(file_id: FileId, path: Path) {
+        FILE_ID_TO_PATH.with_borrow_mut(|map| {
+            map.insert(file_id, path.clone());
+        });
+        FILE_PATH_TO_ID.with_borrow_mut(|map| {
+            map.insert(path, file_id);
+        });
+    }
+
+    /// Exists check for a file path.
+    pub fn exists(path: &Path) -> bool {
+        FILE_PATH_TO_ID.with_borrow(|map| map.contains_key(path))
+    }
+
+    /// Remove a [`FileId`] from the storage.
+    pub fn unlink(file_id: FileId) {
+        let path_to_remove = FILE_ID_TO_PATH.with_borrow_mut(|map| map.remove(&file_id));
+        if let Some(path) = path_to_remove {
+            FILE_PATH_TO_ID.with_borrow_mut(|map| {
+                map.remove(&path);
+            });
+        }
+    }
+
+    /// Rename a file path in the storage.
+    #[allow(dead_code)]
+    pub fn rename(file_id: FileId, new_path: Path) {
+        // Remove the old path
+        Self::unlink(file_id);
+        // Set the new path
+        Self::create(file_id, new_path);
+    }
+
+    /// Get the [`Path`] for a given [`FileId`].
+    pub fn read_link(file_id: &FileId) -> Option<Path> {
+        FILE_ID_TO_PATH.with_borrow(|map| map.get(file_id))
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_insert_and_read_link() {
+        let file_id = 1;
+        let path = Path::new("/test/file.txt").expect("invalid path");
+
+        PathStorage::create(file_id, path.clone());
+        assert!(PathStorage::exists(&path));
+        assert_eq!(PathStorage::read_link(&file_id), Some(path));
+    }
+
+    #[test]
+    fn test_should_unlink() {
+        let file_id = 2;
+        let path = Path::new("/test/file2.txt").expect("invalid path");
+
+        PathStorage::create(file_id, path.clone());
+        assert!(PathStorage::exists(&path));
+
+        PathStorage::unlink(file_id);
+        assert!(!PathStorage::exists(&path));
+        assert_eq!(PathStorage::read_link(&file_id), None);
+    }
+
+    #[test]
+    fn test_should_rename() {
+        let file_id = 3;
+        let old_path = Path::new("/test/old_file.txt").expect("invalid path");
+        let new_path = Path::new("/test/new_file.txt").expect("invalid path");
+
+        PathStorage::create(file_id, old_path.clone());
+        assert!(PathStorage::exists(&old_path));
+        assert_eq!(
+            PathStorage::read_link(&file_id).expect("no such file"),
+            old_path
+        );
+
+        PathStorage::rename(file_id, new_path.clone());
+        assert!(!PathStorage::exists(&old_path));
+        assert!(PathStorage::exists(&new_path));
+        assert_eq!(PathStorage::read_link(&file_id), Some(new_path));
+    }
+}

--- a/backend/user_canister/src/storage/memory.rs
+++ b/backend/user_canister/src/storage/memory.rs
@@ -6,11 +6,13 @@ pub const ORCHESTRATOR_MEMORY_ID: MemoryId = MemoryId::new(2);
 pub const OWNER_PUBLIC_KEY_MEMORY_ID: MemoryId = MemoryId::new(3);
 
 pub const FILE_COUNT_MEMORY_ID: MemoryId = MemoryId::new(10);
-pub const OWNED_FILES_MEMORY_ID: MemoryId = MemoryId::new(11);
-pub const FILE_DATA_MEMORY_ID: MemoryId = MemoryId::new(12);
-pub const FILE_ALIAS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(13);
-pub const FILE_SHARES_MEMORY_ID: MemoryId = MemoryId::new(14);
-pub const FILE_CONTENTS_MEMORY_ID: MemoryId = MemoryId::new(15);
+pub const FILE_ID_TO_PATH_MEMORY_ID: MemoryId = MemoryId::new(11);
+pub const FILE_PATH_TO_ID_MEMORY_ID: MemoryId = MemoryId::new(12);
+pub const OWNED_FILES_MEMORY_ID: MemoryId = MemoryId::new(13);
+pub const FILE_DATA_MEMORY_ID: MemoryId = MemoryId::new(14);
+pub const FILE_ALIAS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(15);
+pub const FILE_SHARES_MEMORY_ID: MemoryId = MemoryId::new(16);
+pub const FILE_CONTENTS_MEMORY_ID: MemoryId = MemoryId::new(17);
 
 thread_local! {
   /// Memory manager

--- a/integration-tests/src/pocket_ic/user_canister_client.rs
+++ b/integration-tests/src/pocket_ic/user_canister_client.rs
@@ -3,8 +3,9 @@ use did::FileId;
 use did::orchestrator::PublicKey;
 use did::user_canister::{
     AliasInfo, DeleteFileResponse, FileDownloadResponse, FileSharingResponse, GetAliasInfoError,
-    OwnerKey, PublicFileMetadata, UploadFileAtomicRequest, UploadFileContinueRequest,
-    UploadFileContinueResponse, UploadFileError, UploadFileRequest,
+    OwnerKey, Path, PublicFileMetadata, RequestFileResponse, UploadFileAtomicRequest,
+    UploadFileAtomicResponse, UploadFileContinueRequest, UploadFileContinueResponse,
+    UploadFileError, UploadFileRequest,
 };
 
 use super::PocketIcTestEnv;
@@ -105,10 +106,10 @@ impl UserCanisterClient<'_> {
         &self,
         request: UploadFileAtomicRequest,
         caller: Principal,
-    ) -> u64 {
+    ) -> UploadFileAtomicResponse {
         let payload = candid::encode_args((request,)).unwrap();
         self.pic
-            .update::<u64>(
+            .update::<UploadFileAtomicResponse>(
                 self.pic.user_canister(),
                 caller,
                 "upload_file_atomic",
@@ -135,10 +136,15 @@ impl UserCanisterClient<'_> {
             .expect("Failed to continue file upload")
     }
 
-    pub async fn request_file(&self, request_name: String, caller: Principal) -> String {
-        let payload = candid::encode_args((request_name,)).unwrap();
+    pub async fn request_file(&self, path: Path, caller: Principal) -> RequestFileResponse {
+        let payload = candid::encode_args((path,)).unwrap();
         self.pic
-            .update::<String>(self.pic.user_canister(), caller, "request_file", payload)
+            .update::<RequestFileResponse>(
+                self.pic.user_canister(),
+                caller,
+                "request_file",
+                payload,
+            )
             .await
             .expect("Failed to request file")
     }

--- a/integration-tests/tests/pocket_ic/orchestrator.rs
+++ b/integration-tests/tests/pocket_ic/orchestrator.rs
@@ -112,11 +112,11 @@ async fn test_should_return_shared_files(env: PocketIcTestEnv) {
 
     // admin creates a file and shares it with alice
     let user_canister_client = UserCanisterClient::from(&env);
-    let request_name = "test.txt".to_string();
+    let path = "/test.txt".to_string().try_into().unwrap();
     let file_id = user_canister_client
         .upload_file_atomic(
             UploadFileAtomicRequest {
-                name: request_name.clone(),
+                path,
                 content: vec![1, 2, 3],
                 file_type: "txt".to_string(),
                 owner_key: [1; OwnerKey::KEY_SIZE].into(),
@@ -124,7 +124,8 @@ async fn test_should_return_shared_files(env: PocketIcTestEnv) {
             },
             owner,
         )
-        .await;
+        .await
+        .unwrap();
 
     // share file with alice
     assert_eq!(


### PR DESCRIPTION
A Path has been introduced to allow folders and a more structural file system for the UI. There is not (at least for now) FS tree, but they work as in S3, so the File Path it's the file name and from that the folders are derived. This required some API change to provide the File Path instead of the File name in the candid interface. The file path has been implemented as a new Type which wraps a String, but with some custom validation. For instance if a Path is being deserialized and it's either empty or it won't start with /, the deserialization will fail.

BREAKING CHANGE: changed request and response for request_file and upload_file_atomic